### PR TITLE
Correct stopping of Batch jobs and jobs in Interactive sesions

### DIFF
--- a/client-common/src/main/java/com/cloudera/livy/client/common/HttpMessages.java
+++ b/client-common/src/main/java/com/cloudera/livy/client/common/HttpMessages.java
@@ -108,12 +108,18 @@ public class HttpMessages {
 
     public final long id;
     public final State state;
+    public final String sparkJobId;
     public final byte[] result;
     public final String error;
 
     public JobStatus(long id, State state, byte[] result, String error) {
+      this(id, state, null, result, error);
+    }
+
+    public JobStatus(long id, State state, String sparkJobId, byte[] result, String error) {
       this.id = id;
       this.state = state;
+      this.sparkJobId = sparkJobId;
       this.error = error;
 
       // json4s, at least, seems confused about whether a "null" in the JSON payload should
@@ -121,9 +127,6 @@ public class HttpMessages {
       // valid serialized object in a byte array of size 0, translate that to null.
       this.result = (result != null && result.length > 0) ? result : null;
 
-      if (this.result != null && state != State.SUCCEEDED) {
-        throw new IllegalArgumentException("Result cannot be set unless job succeeded.");
-      }
       // The check for "result" is not completely correct, but is here to make the unit tests work.
       if (this.result == null && error != null && state != State.FAILED) {
         throw new IllegalArgumentException("Error cannot be set unless job failed.");
@@ -131,7 +134,7 @@ public class HttpMessages {
     }
 
     private JobStatus() {
-      this(-1, null, null, null);
+      this(-1, null, null, null, null);
     }
 
   }

--- a/rsc/src/main/java/com/cloudera/livy/rsc/driver/JobWrapper.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/driver/JobWrapper.java
@@ -132,7 +132,7 @@ public class JobWrapper<T> implements Callable<Void> {
       LOG.info("Job group " + jobId + " finished");
       driver.jobFinished(jobId, result, null);
       state = JobHandle.State.SUCCEEDED;
-    } else {
+    } else if (state != JobHandle.State.CANCELLED) {
       LOG.info("Job group " + jobId + " failed");
       driver.jobFinished(jobId, null, error);
       state = JobHandle.State.FAILED;

--- a/rsc/src/main/java/com/cloudera/livy/rsc/driver/JobWrapper.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/driver/JobWrapper.java
@@ -79,6 +79,9 @@ public class JobWrapper<T> implements Callable<Void> {
   @Override
   public Void call() throws Exception {
     try {
+      driver.jobContext().sc().setJobGroup(jobId, jobId);
+      LOG.info("Job group " + jobId + " started");
+
       jobStarted();
       state = JobHandle.State.STARTED;
 
@@ -107,6 +110,10 @@ public class JobWrapper<T> implements Callable<Void> {
     this.future = executor.submit(this);
   }
 
+  public Job<T> getJob() {
+    return job;
+  }
+
   void jobDone() {
     synchronized (completed) {
       completed.incrementAndGet();
@@ -115,16 +122,18 @@ public class JobWrapper<T> implements Callable<Void> {
   }
 
   boolean cancel() {
-    state = JobHandle.State.CANCELLED;
     driver.jobContext().sc().cancelJobGroup(jobId);
-    return future == null || future.cancel(true);
+    state = JobHandle.State.CANCELLED;
+    return true;
   }
 
   protected void finished(T result, Throwable error) {
     if (error == null) {
+      LOG.info("Job group " + jobId + " finished");
       driver.jobFinished(jobId, result, null);
       state = JobHandle.State.SUCCEEDED;
     } else {
+      LOG.info("Job group " + jobId + " failed");
       driver.jobFinished(jobId, null, error);
       state = JobHandle.State.FAILED;
     }

--- a/rsc/src/main/java/com/cloudera/livy/rsc/driver/RSCDriver.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/driver/RSCDriver.java
@@ -117,7 +117,7 @@ public class RSCDriver extends BaseProtocol {
 
     // Cancel any pending jobs.
     for (JobWrapper<?> job : activeJobs.values()) {
-      job.cancel(executor);
+      job.cancel();
     }
 
     try {
@@ -370,7 +370,7 @@ public class RSCDriver extends BaseProtocol {
 
   public void handle(ChannelHandlerContext ctx, CancelJob msg) {
     JobWrapper<?> job = activeJobs.get(msg.id);
-    if (job == null || !job.cancel(executor)) {
+    if (job == null || !job.cancel()) {
       LOG.info("Requested to cancel an already finished job.");
     }
   }

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSessionServlet.scala
@@ -157,8 +157,8 @@ class InteractiveSessionServlet(livyConf: LivyConf)
         } else {
           req.args
         }
-        val jobId = session.runClass(req.className, args)
-        Created(new JobStatus(jobId, JobHandle.State.SENT, null, null))
+        val (opId, jobId) = session.runClass(req.className, args)
+        Created(new JobStatus(opId, JobHandle.State.SENT, jobId, null, null))
       } catch {
         case e: Throwable =>
           e.printStackTrace()
@@ -222,6 +222,12 @@ class InteractiveSessionServlet(livyConf: LivyConf)
     withSession { lsession =>
       val uri = new URI(req.uri)
       lsession.addFile(uri)
+    }
+  }
+
+  get("/:id/jobs") {
+    withSession { lsession =>
+      Ok(lsession.jobs)
     }
   }
 

--- a/server/src/main/scala/com/cloudera/livy/utils/NewSparkProcessBuilder.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/NewSparkProcessBuilder.scala
@@ -1,0 +1,100 @@
+package com.cloudera.livy.utils
+
+import com.cloudera.livy.{LivyConf, Logging}
+import org.apache.spark.launcher.{SparkAppHandle, SparkLauncher}
+
+import scala.collection.mutable
+
+class NewSparkProcessBuilder(livyConf: LivyConf) extends Logging {
+  private[this] val _conf                       = mutable.HashMap[String, String]()
+  private[this] var _deployMode: Option[String] = None
+  private[this] var _className : Option[String] = None
+  private[this] var _name      : Option[String] = Some("Livy")
+  private[this] var _proxyUser : Option[String] = None
+  private[this] var _queue     : Option[String] = None
+
+  def conf(key: String): Option[String] = {
+    _conf.get(key)
+  }
+
+  def conf(key: String, value: String, admin: Boolean = false) = {
+    _conf(key) = value
+  }
+
+  def conf(conf: Traversable[(String, String)]): Unit = {
+    conf.foreach { case (key, value) => this.conf(key, value) }
+  }
+
+  def className(className: String) = {
+    _className = Some(className)
+  }
+
+  def deployMode(deployMode: String) = {
+    _deployMode = Some(deployMode)
+  }
+
+  def driverMemory(driverMemory: String) = {
+    conf("spark.driver.memory", driverMemory)
+  }
+
+  def driverCores(driverCores: Int): Unit = {
+    this.driverCores(driverCores.toString)
+  }
+
+  def driverCores(driverCores: String) = {
+    conf("spark.driver.cores", driverCores)
+  }
+
+  def executorCores(executorCores: Int): Unit = {
+    this.executorCores(executorCores.toString)
+  }
+
+  def executorCores(executorCores: String) = {
+    conf("spark.executor.cores", executorCores)
+  }
+
+  def executorMemory(executorMemory: String) = {
+    conf("spark.executor.memory", executorMemory)
+  }
+
+  def numExecutors(numExecutors: Int): Unit = {
+    this.numExecutors(numExecutors.toString)
+  }
+
+  def numExecutors(numExecutors: String) = {
+    this.conf("spark.executor.instances", numExecutors)
+  }
+
+  def proxyUser(proxyUser: String) = {
+    _proxyUser = Some(proxyUser)
+  }
+
+  def queue(queue: String) = {
+    _queue = Some(queue)
+  }
+
+  def name(name: String) = {
+    _name = Some(name)
+  }
+
+  def start(file: Option[String], args: Traversable[String]): SparkAppHandle = {
+    val launcher = new SparkLauncher()
+
+    _deployMode.foreach(launcher.setDeployMode)
+    _name.foreach(launcher.setAppName)
+    _className.foreach(launcher.setMainClass)
+
+    _conf.foreach({ case (k, v) => launcher.setConf(k, v) })
+
+    file.foreach(launcher.setAppResource)
+
+    val argsString = args
+      .map("'" + _.replace("'", "\\'") + "'")
+      .mkString(" ")
+
+    info(s"Running $argsString")
+
+    launcher.addAppArgs(argsString)
+    launcher.startApplication()
+  }
+}


### PR DESCRIPTION
1. For Batch jobs use `SparkAppHandle` to stop jobs. See more here: https://issues.apache.org/jira/browse/SPARK-8673

2. For jobs submitted to a Interactive session use spark job groups.

3. Added `job group id` to the JobStatus.

4. Added `GET /sessions/:id/jobs` call.