### PR TITLE
Fix timeouts for running sessions

### DIFF
--- a/server/src/main/scala/com/cloudera/livy/sessions/Session.scala
+++ b/server/src/main/scala/com/cloudera/livy/sessions/Session.scala
@@ -57,10 +57,9 @@ abstract class Session(val id: String, val owner: String, val livyConf: LivyConf
     case SessionState.Error(time) => time
     case SessionState.Dead(time) => time
     case SessionState.Success(time) => time
+    case SessionState.Running() => System.nanoTime()
     case _ => _lastActivity
   }
-
-  val timeout: Long = TimeUnit.HOURS.toNanos(1)
 
   def state: SessionState
 

--- a/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
+++ b/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
@@ -72,6 +72,7 @@ class SessionManager[S <: Session](val livyConf: LivyConf) extends Logging {
   }
 
   def delete(session: S): Future[Unit] = {
+    info("Stopping session: " + session.id)
     session.stop()
   }
 
@@ -85,7 +86,7 @@ class SessionManager[S <: Session](val livyConf: LivyConf) extends Logging {
   def collectGarbage(): Future[Iterable[Unit]] = {
     def expired(session: Session): Boolean = {
       val currentTime = System.nanoTime()
-      currentTime - session.lastActivity > math.max(sessionTimeout, session.timeout)
+      currentTime - session.lastActivity > sessionTimeout
     }
 
     Future.sequence(all().filter(expired).map(delete))

--- a/server/src/test/scala/com/cloudera/livy/sessions/MockSession.scala
+++ b/server/src/test/scala/com/cloudera/livy/sessions/MockSession.scala
@@ -31,8 +31,6 @@ class MockSession(id: String, owner: String, conf: LivyConf) extends Session(id,
 
   override def state: SessionState = SessionState.Idle()
 
-  override val timeout: Long = 0L
-
   override def resolveURIs(uris: Seq[String]): Seq[String] = super.resolveURIs(uris)
 
   override def resolveURI(uri: URI): URI = super.resolveURI(uri)


### PR DESCRIPTION
1. Allow settings timeouts that are lower than 1hr.

2. Report correct time for active sessions (both batch and interactive).